### PR TITLE
add content-length to post requests

### DIFF
--- a/src/puppy.nim
+++ b/src/puppy.nim
@@ -68,6 +68,9 @@ proc addDefaultHeaders(req: Request) =
   if req.headers["accept-encoding"].len == 0:
     # If there isn't a specific accept-encoding specified, enable gzip
     req.headers["accept-encoding"] = "gzip"
+  if req.headers["content-length"].len == 0 and req.body.len > 0:
+    req.headers["content-length"] = $req.body.len
+
 
 when defined(windows) and not defined(puppyLibcurl):
   # WinHTTP Windows

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -117,6 +117,7 @@ try:
       doAssert ($req).startsWith("POST /post HTTP/1.1")
       doAssert res.code == 200
       doAssert res.body == "some data"
+      doAssert req.headers["Content-Length"] == $res.body.len
 
     block:
       # test post + gzip


### PR DESCRIPTION
Currently puppy is not sending `Content-Length` header during POST requests. Such request will likely fail as server requires this header to be present if post data is to be received. 

My implementation adds it during `addDefaultHeaders` call if it's not already set by user. Appropriate test was created as well.