### PR TITLE
Add dlprogress callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ echo res.headers
 echo res.body.len
 ```
 
+Get download progress?
+
+```nim
+import puppy
+
+proc reportProgress(userp: pointer; total, current: int) =
+  echo total,' ',current
+
+echo fetch("http://neverssl.com/", onDLProgress = ProgressCallback(callback: reportProgress))
+```
+
 # Always use Libcurl
 
 You can pass `-d:puppyLibcurl` to force use of `libcurl` even on windows and macOS. This is useful to debug, if the some reason native OS API does not work. Libcurl is usually installed on macOS but requires a `curl.dll` on windows.

--- a/src/puppy.nim
+++ b/src/puppy.nim
@@ -19,7 +19,7 @@ proc addDefaultHeaders(req: Request) =
     # If there isn't a specific accept-encoding specified, enable gzip
     req.headers["accept-encoding"] = "gzip"
 
-proc fetch*(req: Request, onprogress: proc(dltotal, dlnow, ultotal, ulnow: int) {.closure} = nil): Response {.raises: [PuppyError].} =
+proc fetch*(req: Request, onDLProgress: ProgressCallback = ProgressCallback()): Response {.raises: [PuppyError].} =
   if req.url.scheme notin ["http", "https"]:
     raise newException(
       PuppyError, "Unsupported request scheme: " & req.url.scheme
@@ -30,7 +30,7 @@ proc fetch*(req: Request, onprogress: proc(dltotal, dlnow, ultotal, ulnow: int) 
   if req.timeout == 0:
     req.timeout = 60
 
-  platform.fetch(req, onprogress)
+  platform.fetch(req, onDLProgress)
 
 proc newRequest*(
   url: string,
@@ -45,10 +45,10 @@ proc newRequest*(
   result.headers = headers
   result.timeout = timeout
 
-proc fetch*(url: string, headers = newSeq[Header](), onprogress: proc(dltotal, dlnow, ultotal, ulnow: int) = nil): string =
+proc fetch*(url: string, headers = newSeq[Header](), onDLProgress: ProgressCallback = ProgressCallback()): string =
   let
     req = newRequest(url, "get", headers)
-    res = req.fetch(onprogress)
+    res = req.fetch(onDLProgress)
   if res.code == 200:
     return res.body
   raise newException(PuppyError,

--- a/src/puppy/common.nim
+++ b/src/puppy/common.nim
@@ -23,6 +23,10 @@ type
 
   PuppyError* = object of IOError ## Raised if an operation fails.
 
+  ProgressCallback* = object
+    userp*: pointer
+    callback*: proc(userp: pointer; total, current: int)
+
 proc `[]`*(headers: seq[Header], key: string): string =
   ## Get a key out of headers. Not case sensitive.
   ## Use a for loop to get multiple keys.

--- a/src/puppy/common.nim
+++ b/src/puppy/common.nim
@@ -24,8 +24,8 @@ type
   PuppyError* = object of IOError ## Raised if an operation fails.
 
   ProgressCallback* = object
-    userp*: pointer
-    callback*: proc(userp: pointer; total, current: int)
+    clientp*: pointer
+    callback*: proc(clientp: pointer; total, current: int)
 
 proc `[]`*(headers: seq[Header], key: string): string =
   ## Get a key out of headers. Not case sensitive.

--- a/src/puppy/platforms/linux/platform.nim
+++ b/src/puppy/platforms/linux/platform.nim
@@ -11,7 +11,7 @@ type StringWrap = object
 proc cProgressCallback(clientp: pointer; dltotal, dlnow, ultotal, ulnow: cdouble): cint {.cdecl, raises: [].} =
   try:
     let cbPtr = cast[ptr ProgressCallback](clientp)
-    cbPtr.callback(cbPtr.userp, dltotal.int, dlnow.int)
+    cbPtr.callback(cbPtr.clientp, dltotal.int, dlnow.int)
   except:
     echo getCurrentExceptionMsg()
     quit(1)

--- a/src/puppy/platforms/win32/platform.nim
+++ b/src/puppy/platforms/win32/platform.nim
@@ -224,10 +224,10 @@ proc fetch*(req: Request, onDLProgress: ProgressCallback): Response {.raises: [P
 
       if not isNil onDLProgress.callback:
         try:
-          onDLProgress.callback(onDLProgress.userp, contentLength, i)
+          onDLProgress.callback(onDLProgress.clientp, contentLength, i)
         except:
           raise newException(
-            PuppyError, "ProgressCallback invalid userp pointer"
+            PuppyError, "ProgressCallback invalid clientp pointer"
           )
       if i == result.body.len:
         result.body.setLen(min(i * 2, i + 100 * 1024 * 1024))

--- a/src/puppy/platforms/win32/platform.nim
+++ b/src/puppy/platforms/win32/platform.nim
@@ -1,6 +1,6 @@
 import puppy/common, std/strutils, utils, windefs, zippy
 
-proc fetch*(req: Request): Response {.raises: [PuppyError].} =
+proc fetch*(req: Request, onDLProgress: ProgressCallback): Response {.raises: [PuppyError].} =
   result = Response()
 
   var hSession, hConnect, hRequest: HINTERNET
@@ -187,6 +187,20 @@ proc fetch*(req: Request): Response {.raises: [PuppyError].} =
             key: parts[0].strip(),
             value: parts[1].strip()
           ))
+    
+    var contentLength = 0
+    block:
+      var contentLengthValue = ""
+      try:
+        for header in result.headers:
+          if header.key == "Content-Length":
+            contentLengthValue = header.value
+            contentLength = parseInt(header.value)
+      except ValueError:
+        raise newException(
+          PuppyError,
+          "Content-Length error: '" & contentLengthValue & "' not an integer."
+        )
 
     var i: int
     result.body.setLen(8192)
@@ -208,6 +222,13 @@ proc fetch*(req: Request): Response {.raises: [PuppyError].} =
       if bytesRead == 0:
         break
 
+      if not isNil onDLProgress.callback:
+        try:
+          onDLProgress.callback(onDLProgress.userp, contentLength, i)
+        except:
+          raise newException(
+            PuppyError, "ProgressCallback invalid userp pointer"
+          )
       if i == result.body.len:
         result.body.setLen(min(i * 2, i + 100 * 1024 * 1024))
 


### PR DESCRIPTION
Summary:
* Adds download progress callbacks. Comment, reject, help? :)
* osx delegate-wrapping has me stumped. Anyone have experience or can point me in the right direction?

I really need minimal x-platform download progress for a project. To my knowledge no nim lib exists that allows this, but puppy is the closest. It would be ideal to also implement upload progress, but I figure one thing at a time. Also, download progress is far more common of a need than upload progress -- so a phased development doesn't seem horrible.

What's working in this PR:
* linux `libcurl` download progress callback
* windows `WinHTTP` download progress callback

Features:
* very simple download progress callbacks (total, current: int; an optional user pointer) trying to keep with puppy's minimalism
* could be extended to support upload callbacks later in the same way

Assumptions:
* The user is responsible for caring about concurrency, if it's important to them. But this is easy enough.

What needs help or guidance:
* how can the objc code in this repo be used to create a delegate for the `NSURLConnectionDelegate` type?
It looks like everything necessary is there to make this relatively easy. I have some guesses about how to use the templates, but there's a complex dance of declarations and registrations that needs to happen, and I'm at a loss. So far I've been looking into other delegate wrappers for understanding, like in the older nim objc project by jangko, and rust's objc wrapper.
