### PR TITLE
Add `get` and `post` functions akin to python requests module

### DIFF
--- a/src/puppy.nim
+++ b/src/puppy.nim
@@ -67,11 +67,11 @@ proc get(url: string): string =
     let res = fetch(req).body
     return res
 
-proc post(url: string, body:string): JsonNode =
+proc post(url: string, body:string): string =
     let req = Request(
     url: parseUrl(url),
     verb: "post",
     body: body
     )
-    let res = parseJson(fetch(req).body)
+    let res = fetch(req).body
     return res

--- a/src/puppy.nim
+++ b/src/puppy.nim
@@ -1,5 +1,6 @@
 import puppy/common, urlly
 
+
 when defined(windows) and not defined(puppyLibcurl):
   # WinHTTP Windows
   import puppy/platforms/win32/platform
@@ -54,3 +55,23 @@ proc fetch*(url: string, headers = newSeq[Header]()): string =
   raise newException(PuppyError,
     "Non 200 response code: " & $res.code & "\n" & res.body
   )
+
+
+# these more closely match how my mind works
+import std/json
+proc get(url: string): string =
+    let req = Request(
+    url: parseUrl(url),
+    verb: "get",
+    )
+    let res = fetch(req).body
+    return res
+
+proc post(url: string, body:string): JsonNode =
+    let req = Request(
+    url: parseUrl(url),
+    verb: "post",
+    body: body
+    )
+    let res = parseJson(fetch(req).body)
+    return res

--- a/src/puppy.nim
+++ b/src/puppy.nim
@@ -57,8 +57,8 @@ proc fetch*(url: string, headers = newSeq[Header]()): string =
   )
 
 
-# these more closely match how my mind works
-import std/json
+# these more closely match how my mind works and python requests module work.
+
 proc get(url: string): string =
     let req = Request(
     url: parseUrl(url),


### PR DESCRIPTION
Hey there. 

I appreciate the work that's been put in so far by puppy.
 
I think nimlang forcing you to ship external DLLs for SSL support is kind of whack... 

puppy not requiring extra compile time flags is a win too.

I think there is an opportunity for an improved user experience regarding making requests via puppy. 

I think having `get` and `post` functions would be a good start. Could you implement all the verbs? maybe... but those two are essential. 

It would help reduce friction for sending data for newcomers to nm. 

I wasn't smart enough to figure out how to have generic headers that can be overridden like in python. 

I heard there was an `Option[T]` but I'm not sure how that works. 
