### PR TITLE
add github token, checkout v3, global init

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: jiro4989/setup-nim-action@v1
       with:
         nim-version: ${{ matrix.nim-version }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - run: nimble install -y libcurl
     - run: nimble install -y zippy

--- a/puppy.nimble
+++ b/puppy.nimble
@@ -1,4 +1,4 @@
-version     = "2.0.1"
+version     = "2.0.2"
 author      = "Andre von Houck"
 description = "Puppy fetches resources via HTTP and HTTPS."
 license     = "MIT"

--- a/src/puppy/platforms/linux/platform.nim
+++ b/src/puppy/platforms/linux/platform.nim
@@ -1,5 +1,10 @@
 import libcurl, puppy/common, std/strutils, zippy
 
+block:
+  let ret = global_init(GLOBAL_DEFAULT)
+  if ret != E_OK:
+    raise newException(Defect, $easy_strerror(ret))
+
 type StringWrap = object
   ## As strings are value objects they need
   ## some sort of wrapper to be passed to C.

--- a/src/puppy/platforms/linux/platform.nim
+++ b/src/puppy/platforms/linux/platform.nim
@@ -74,8 +74,10 @@ proc fetch*(req: Request): Response {.raises: [PuppyError].} =
   # On Windows look for cacert.pem.
   when defined(windows):
     discard curl.easy_setopt(OPT_CAINFO, "cacert.pem".cstring)
-  # Follow redirects by default.
+
+  # Follow up to 10 redirects by default.
   discard curl.easy_setopt(OPT_FOLLOWLOCATION, 1)
+  discard curl.easy_setopt(OPT_MAXREDIRS, 10)
 
   if req.allowAnyHttpsCertificate:
     discard curl.easy_setopt(OPT_SSL_VERIFYPEER, 0)

--- a/src/puppy/platforms/linux/platform.nim
+++ b/src/puppy/platforms/linux/platform.nim
@@ -1,6 +1,11 @@
 import libcurl, puppy/common, std/strutils, zippy
 
 block:
+  ## If you did not already call curl_global_init then
+  ## curl_easy_init does it automatically.
+  ## This may be lethal in multi-threaded cases since curl_global_init
+  ## is not thread-safe.
+  ## https://curl.se/libcurl/c/curl_easy_init.html
   let ret = global_init(GLOBAL_DEFAULT)
   if ret != E_OK:
     raise newException(Defect, $easy_strerror(ret))


### PR DESCRIPTION
> If you did not already call [curl_global_init](https://curl.se/libcurl/c/curl_global_init.html), [curl_easy_init](https://curl.se/libcurl/c/curl_easy_init.html) does it automatically. This may be lethal in multi-threaded cases, since [curl_global_init](https://curl.se/libcurl/c/curl_global_init.html) is not thread-safe, and it may result in resource problems because there is no corresponding cleanup.

https://curl.se/libcurl/c/curl_easy_init.html