### PR TITLE
Add url field to Response

### DIFF
--- a/src/puppy/common.nim
+++ b/src/puppy/common.nim
@@ -17,6 +17,7 @@ type
 
   Response* = ref object
     headers*: HttpHeaders
+    url*: string
     code*: int
     body*: string
 

--- a/src/puppy/platforms/macos/macdefs.nim
+++ b/src/puppy/platforms/macos/macdefs.nim
@@ -51,3 +51,5 @@ objc:
   ): NSData
   proc statusCode*(self: NSHTTPURLResponse): int
   proc allHeaderFields*(self: NSHTTPURLResponse): NSDictionary
+  proc URL*(self: NSHTTPURLResponse): NSURL
+  proc absoluteString*(self: NSURL): NSString

--- a/src/puppy/platforms/macos/platform.nim
+++ b/src/puppy/platforms/macos/platform.nim
@@ -30,6 +30,8 @@ proc fetch*(req: Request): Response {.raises: [PuppyError].} =
     if response.int != 0:
       result.code = response.statusCode
 
+      result.url = $(response.URL.absoluteString)
+
       let
         dictionary = response.allHeaderFields
         keyEnumerator = dictionary.keyEnumerator

--- a/src/puppy/platforms/win32/platform.nim
+++ b/src/puppy/platforms/win32/platform.nim
@@ -187,7 +187,7 @@ proc fetch*(req: Request): Response {.raises: [PuppyError].} =
       responseUrlBytes: DWORD
       responseUrlBuf: string
 
-    # Determine how big the header buffer needs to be
+    # Determine how big the URL buffer needs to be
     discard WinHttpQueryOption(
       hRequest,
       WINHTTP_OPTION_URL,
@@ -196,12 +196,12 @@ proc fetch*(req: Request): Response {.raises: [PuppyError].} =
     )
     var errorCode = GetLastError()
     if errorCode == ERROR_INSUFFICIENT_BUFFER: # Expected!
-      # Set the header buffer to the correct size and inclue a null terminator
+      # Set the URL buffer to the correct size and inclue a null terminator
       responseUrlBuf.setLen(responseUrlBytes)
     else:
       raise newException(PuppyError, "WinHttpQueryOption error: " & $errorCode)
 
-    # Read the headers into the buffer
+    # Read the URL into the buffer
     if WinHttpQueryOption(
       hRequest,
       WINHTTP_OPTION_URL,

--- a/src/puppy/platforms/win32/platform.nim
+++ b/src/puppy/platforms/win32/platform.nim
@@ -1,4 +1,4 @@
-import puppy/common, std/strutils, utils, windefs, zippy, webby
+import puppy/common, std/strutils, utils, windefs, zippy
 
 proc fetch*(req: Request): Response {.raises: [PuppyError].} =
   result = Response()

--- a/src/puppy/platforms/win32/platform.nim
+++ b/src/puppy/platforms/win32/platform.nim
@@ -1,4 +1,4 @@
-import puppy/common, std/strutils, utils, windefs, zippy
+import puppy/common, std/strutils, utils, windefs, zippy, webby
 
 proc fetch*(req: Request): Response {.raises: [PuppyError].} =
   result = Response()
@@ -184,6 +184,35 @@ proc fetch*(req: Request): Response {.raises: [PuppyError].} =
 
     result.code = statusCode
     var
+      responseUrlBytes: DWORD
+      responseUrlBuf: string
+
+    # Determine how big the header buffer needs to be
+    discard WinHttpQueryOption(
+      hRequest,
+      WINHTTP_OPTION_URL,
+      nil,
+      responseUrlBytes.addr
+    )
+    var errorCode = GetLastError()
+    if errorCode == ERROR_INSUFFICIENT_BUFFER: # Expected!
+      # Set the header buffer to the correct size and inclue a null terminator
+      responseUrlBuf.setLen(responseUrlBytes)
+    else:
+      raise newException(PuppyError, "WinHttpQueryOption error: " & $errorCode)
+
+    # Read the headers into the buffer
+    if WinHttpQueryOption(
+      hRequest,
+      WINHTTP_OPTION_URL,
+      responseUrlBuf[0].addr,
+      responseUrlBytes.addr,
+    ) == 0:
+      raise newException(PuppyError, "WinHttpQueryOption error: " & $errorCode)
+
+    result.url = $cast[ptr WCHAR](responseUrlBuf[0].addr)
+
+    var
       responseHeaderBytes: DWORD
       responseHeaderBuf: string
 
@@ -196,7 +225,7 @@ proc fetch*(req: Request): Response {.raises: [PuppyError].} =
       responseHeaderBytes.addr,
       nil
     )
-    let errorCode = GetLastError()
+    errorCode = GetLastError()
     if errorCode == ERROR_INSUFFICIENT_BUFFER: # Expected!
       # Set the header buffer to the correct size and inclue a null terminator
       responseHeaderBuf.setLen(responseHeaderBytes)

--- a/src/puppy/platforms/win32/windefs.nim
+++ b/src/puppy/platforms/win32/windefs.nim
@@ -42,6 +42,7 @@ const
   ERROR_INTERNET_SEC_CERT_REVOKED* = 12170
 
   WINHTTP_OPTION_SECURITY_FLAGS* = 31
+  WINHTTP_OPTION_URL* = 34
   SECURITY_FLAG_IGNORE_UNKNOWN_CA* = 0x00000100
   # SECURITY_FLAG_IGNORE_WRONG_USAGE* = 0x00000200
   SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE* = 0x00000200
@@ -138,6 +139,13 @@ proc WinHttpQueryHeaders*(
   lpBuffer: LPVOID,
   lpdwBufferLength: LPDWORD,
   lpdwIndex: LPDWORD
+): BOOL {.dynlib: "winhttp".}
+
+proc WinHttpQueryOption*(
+  hRequest: HINTERNET,
+  dwOption: DWORD,
+  lpBuffer: LPVOID,
+  lpdwBufferLength: LPDWORD,
 ): BOOL {.dynlib: "winhttp".}
 
 proc WinHttpReadData*(

--- a/tests/debug_server.nim
+++ b/tests/debug_server.nim
@@ -75,6 +75,11 @@ proc cb(req: Request) {.async.} =
     await req.respond(Http200, $req.url, headers)
     return
 
+  if req.url.path == "/redirect":
+    let headers = newHttpHeaders([("Location", "/ok")])
+    await req.respond(Http301, "", headers)
+    return
+
   await req.respond(Http404, "Not found.")
 
 waitFor server.serve(Port(8080), cb)

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -194,5 +194,14 @@ try:
       doAssert res.headers["1"] == "a"
       doAssert res.headers["2"] == "b"
 
+    block:
+      # test redirect
+      let res = fetch(Request(
+        url: parseUrl("http://localhost:8080/redirect"),
+        verb: "get",
+      ))
+      doAssert res.code == 200
+      doAssert res.url == "http://localhost:8080/ok"
+
 finally:
   debugServer.terminate()


### PR DESCRIPTION
By default, puppy follows redirects, but has no way to know the final URL. This PR adds `url` field to `Response` object, allowing to get the final URL after redirects.
New redirect test passes on:
- Windows with WinHTTP
- Linux with libcurl
- MacOS with AppKit & libcurl  

I couldn't test on Windows with libcurl, but I'm assuming it should work too.
Addresses #96 