### PR TITLE
Make CI faster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,21 +6,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        nim-version: ['1.2.2', '1.2.x', '1.4.x', 'stable']
+        nim-version: ['binary:1.2.2', 'binary:1.2', 'binary:1.4', 'binary:stable']
         include:
-          - nim-version: '1.4.x'
+          - nim-version: 'binary:1.4'
             gc_orc: true
-          - nim-version: 'stable'
+          - nim-version: 'binary:stable'
             gc_orc: true
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3
-    - uses: jiro4989/setup-nim-action@v1
+    - uses: iffy/install-nim@v4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        nim-version: ${{ matrix.nim-version }}
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: ${{ matrix.nim-version }}
 
     - run: nimble install -y libcurl
     - run: nimble install -y zippy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        nim-version: ['binary:1.2.2', 'binary:1.2', 'binary:1.4', 'binary:stable']
+        nim-version: ['1.2.2', 'binary:1.2', 'binary:1.4', 'binary:stable']
         include:
           - nim-version: 'binary:1.4'
             gc_orc: true


### PR DESCRIPTION
I'm coming here from what @guzba mentioned here about slow macOS tests: https://github.com/treeform/pixie/pull/510

This PR makes CI faster for macOS. Here's a comparison:

| | Currently | This PR |
|---|:-:|:-:|
| Total time | 15-16min | 8-9min |
| Cumulative CPU time | 1h 14m 50s | 21m 54s |
| Usage report | [Latest](https://github.com/treeform/puppy/actions/runs/3941331239/usage) | [PR](https://github.com/iffy/puppy/actions/runs/3951803616/usage) |

Granted, there seems to be a flakey test that fails sometimes on macOS, so maybe some of the speedup comes from skipped tests? But if you compare a single macOS test run, you can see the savings during the install step [latest 14:39 run](https://github.com/treeform/puppy/actions/runs/3941331239/jobs/6743606643) vs [this PR 0:48 run](https://github.com/iffy/puppy/actions/runs/3951803616/jobs/6766113284)

I'm not offended if you don't want the PR -- close it if you don't. I just hate to see slow CI builds :)