### PR TITLE
Fix Nim 2.0.0 compile error caused by `_` variables

### DIFF
--- a/src/puppy/platforms/macos/macdefs.nim
+++ b/src/puppy/platforms/macos/macdefs.nim
@@ -27,25 +27,25 @@ const
 
 objc:
   proc code*(self: NSError): int
-  proc dataWithBytes*(class: typedesc[NSData], _: pointer, length: int): NSData
+  proc dataWithBytes*(class: typedesc[NSData], x: pointer, length: int): NSData
   proc bytes*(self: NSData): pointer
   proc length*(self: NSData): int
   proc keyEnumerator*(self: NSDictionary): NSEnumerator
-  proc objectForKey*(self: NSDictionary, _: ID): ID
+  proc objectForKey*(self: NSDictionary, x: ID): ID
   proc nextObject*(self: NSEnumerator): ID
-  proc URLWithString*(class: typedesc[NSURL], _: NSString): NSURL
+  proc URLWithString*(class: typedesc[NSURL], x: NSString): NSURL
   proc requestWithURL*(
     class: typedesc[NSMutableURLRequest],
-    _: NSURL,
+    x: NSURL,
     cachePolicy: NSURLRequestCachePolicy,
     timeoutInterval: NSTimeInterval
   ): NSMutableURLRequest
-  proc setHTTPMethod*(self: NSMutableURLRequest, _: NSString)
-  proc setValue*(self: NSMutableURLRequest, _: NSString, forHTTPHeaderField: NSString)
-  proc setHTTPBody*(self: NSMutableURLRequest, _: NSData)
+  proc setHTTPMethod*(self: NSMutableURLRequest, x: NSString)
+  proc setValue*(self: NSMutableURLRequest, x: NSString, forHTTPHeaderField: NSString)
+  proc setHTTPBody*(self: NSMutableURLRequest, x: NSData)
   proc sendSynchronousRequest*(
     class: typedesc[NSURLConnection],
-    _: NSMutableURLRequest,
+    x: NSMutableURLRequest,
     returningResponse: ptr NSHTTPURLResponse,
     error: ptr NSError
   ): NSData

--- a/src/puppy/platforms/macos/objc.nim
+++ b/src/puppy/platforms/macos/objc.nim
@@ -113,8 +113,8 @@ macro objc*(body: untyped) =
             fixArg.removeSuffix("_mangle")
             sel.add fixArg
           else:
-            if argName != "_":
-              error("Second arugment needs to be _.", arg)
+            if argName != "x":
+              error("Second arugment needs to be x.", arg)
           sel.add ":"
 
           # Add second name and type as is.


### PR DESCRIPTION
Hello, Thank you so much for maintaining tool :) I created a fix PR for the issue below.
- Fix #105

In Nim 2.0.0 released on August 1st, it seems that `_` can no longer be used as a variable due to the following changes.

- https://github.com/nim-lang/Nim/pull/21584
- https://github.com/nim-lang/Nim/issues/20687
- https://github.com/nim-lang/Nim/issues/21435

Currently, only the macOS code had `_` usage, so I replaced it with `x`.

For this pull request, I have confirmed following:
- Successful compilation with Nim 2.0.0 and 1.6.14
- README some sample code works

I would appreciate it if you could review.

Regards,


